### PR TITLE
Fix access denied when editing reusable flexible layouts

### DIFF
--- a/plugins/export_ui/panels_layouts_ui.class.php
+++ b/plugins/export_ui/panels_layouts_ui.class.php
@@ -73,6 +73,8 @@ class panels_layouts_ui extends ctools_export_ui {
       $display->layout_settings = $form_state['item']->settings;
       $display->cache_key = $cache_key;
       $display->editing_layout = TRUE;
+      $display->storage_type = 'panels_layouts_ui';
+      $display->storage_id = 'panels_layouts_ui';
 
       $cache->display = $display;
       $cache->content_types = $content_types;

--- a/plugins/panels_storage/panels_layouts_ui.inc
+++ b/plugins/panels_storage/panels_layouts_ui.inc
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Provides a panels_storage plugin for the reusable flexible layouts UI.
+ */
+
+// Plugin definition
+$plugin = array(
+  'access callback' => 'panels_layouts_ui_panels_storage_access',
+);
+
+/**
+ * Access callback for panels storage.
+ */
+function panels_layouts_ui_panels_storage_access($storage_type, $storage_id, $op, $account) {
+  return user_access('administer panels layouts', $account);
+}


### PR DESCRIPTION
From the D7 issue:

> It works in my testing, however, you'll need to clear the cache (so Panels picks up the new plugin) and if you previously started editing a particular flexible layout, you may need to save it for the change to take effect (because the old Panels display will already be cached in the CTools object cache).
